### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ seed: 42
 - `FedKD` is a placeholder; future work can implement distillation logic.
 - Results are saved in timestamped folders under `results/` to avoid overwriting.
 
----
 
-For any questions or issues, feel free to reach out!---
+For any questions or issues, feel free to reach out!
 
 ## 📊 Comparing Multiple Algorithms
 


### PR DESCRIPTION
## Summary
- tidy up README formatting
- end file cleanly after usage notes for the comparison script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bca06eeb08328bba862d4b6e9c132