### PR TITLE
Align partition strategy configuration

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -9,17 +9,16 @@ class Config:
         # 模型名称
         self.model_name = cfg.get("model_name")
 
-        # 数据路径 (PubTator 格式)
+        # 数据路径 (PubTator 格式) 与切分策略
         data_cfg = cfg.get("data", {})
         self.pubtator_path   = data_cfg.get("pubtator_path")
         self.trng_pmids_path = data_cfg.get("trng_pmids_path")
         self.dev_pmids_path  = data_cfg.get("dev_pmids_path")
         self.test_pmids_path = data_cfg.get("test_pmids_path")
 
-        # 数据切分策略
-        split_cfg = cfg.get("data_split", {})
-        self.partition_strategy = split_cfg.get("partition_strategy", "iid")
-        self.noniid_alpha       = float(split_cfg.get("noniid_alpha", 0.5))
+        # 数据切分策略 (从 data 部分读取)
+        self.partition_strategy = data_cfg.get("partition_strategy", "iid")
+        self.noniid_alpha       = float(data_cfg.get("noniid_alpha", 0.5))
 
         # 联邦学习设置
         federated_cfg = cfg.get("training", {})

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,13 +3,12 @@
 model_name: microsoft/BiomedNLP-PubMedBERT-base-uncased-abstract
 
 data:
-data:
-  pubtator_path: ./data_set/corpus_pubtator.txt               
-  trng_pmids_path: ./data_set/corpus_pubtator_pmids_trng.txt   
-  dev_pmids_path:   ./data_set/corpus_pubtator_pmids_dev.txt    
-  test_pmids_path:  ./data_set/corpus_pubtator_pmids_test.txt   
-  partition_strategy: "iid"     
-  noniid_alpha: 0.5                
+  pubtator_path: ./data_set/corpus_pubtator.txt
+  trng_pmids_path: ./data_set/corpus_pubtator_pmids_trng.txt
+  dev_pmids_path:   ./data_set/corpus_pubtator_pmids_dev.txt
+  test_pmids_path:  ./data_set/corpus_pubtator_pmids_test.txt
+  partition_strategy: "iid"
+  noniid_alpha: 0.5
 
 training:
   algorithm: FedAvg          # Options: FedAvg, FedAdam, FedKD, Centralized


### PR DESCRIPTION
## Summary
- read `partition_strategy` and `noniid_alpha` from the `data` section
- clean up `config.yaml` to include partition settings directly under `data`

## Testing
- `python -m py_compile config/config.py`
- `python - <<'EOF'
from config.config import Config
c = Config('config/config.yaml')
print(c.partition_strategy, c.noniid_alpha)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6887e65ec10c8328ae6fe50bab8cced7