### PR TITLE
Add config info to metrics logs

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -24,7 +24,7 @@ def set_global_seed(seed=42):
 
 def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents, model_init, device):
     result_dir = create_experiment_log_dir(algorithm=cfg.algorithm)
-    log = MetricsLogger()
+    log = MetricsLogger(cfg)
     global_model = model_init().to(device)
 
     for r in range(cfg.rounds):
@@ -71,12 +71,16 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
               f"P {metrics['precision']:.4f} | R {metrics['recall']:.4f} | "
               f"Time {elapsed:.1f}s\n")
 
-    save_json(log.get_logs(), os.path.join(result_dir, "fed_results.json"))
+    save_json({
+        "algorithm": cfg.algorithm,
+        "config": cfg.__dict__,
+        "metrics": log.get_logs(),
+    }, os.path.join(result_dir, "fed_results.json"))
 
 
 def run_centralized_training(cfg, tokenizer, label_list, train_sents, test_sents, model_init, device):
     result_dir = create_experiment_log_dir(algorithm="Centralized")
-    log = MetricsLogger()
+    log = MetricsLogger(cfg)
     model = model_init().to(device)
 
     log.start_timer()
@@ -96,7 +100,11 @@ def run_centralized_training(cfg, tokenizer, label_list, train_sents, test_sents
           f"P {metrics['precision']:.4f} | R {metrics['recall']:.4f} | "
           f"Time {elapsed:.1f}s")
 
-    save_json(log.get_logs(), os.path.join(result_dir, "central_results.json"))
+    save_json({
+        "algorithm": cfg.algorithm,
+        "config": cfg.__dict__,
+        "metrics": log.get_logs(),
+    }, os.path.join(result_dir, "central_results.json"))
 
 
 def main():

--- a/utils/metrics_logger.py
+++ b/utils/metrics_logger.py
@@ -2,9 +2,18 @@ import time
 from collections import defaultdict
 
 class MetricsLogger:
-    def __init__(self):
+    def __init__(self, cfg=None):
+        """Create a new logger.
+
+        Parameters
+        ----------
+        cfg : object, optional
+            Experiment configuration. When provided it is stored on the logger
+            for later use when saving metrics.
+        """
         self.history = defaultdict(list)
         self.start_time = None
+        self.cfg = cfg
 
     def start_timer(self):
         self.start_time = time.time()


### PR DESCRIPTION
## Summary
- allow `MetricsLogger` to store the experiment config
- pass config when creating the logger
- save algorithm name and experiment parameters alongside metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688cd10c80dc8328bd918187430aae9d