### PR TITLE
Pass sequence length and batch size through config

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -37,7 +37,8 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 epochs=cfg.local_epochs,
                 learning_rate=cfg.learning_rate,
                 scheduler_type=cfg.lr_scheduler_type,
-                batch_size=cfg.train_batch_size
+                batch_size=cfg.train_batch_size,
+                max_seq_length=cfg.max_seq_length
             )
         elif cfg.algorithm == "FedProx":
             trainer = FedProxTrainer(
@@ -46,7 +47,8 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 mu=0.1,
                 learning_rate=cfg.learning_rate,
                 scheduler_type=cfg.lr_scheduler_type,
-                batch_size=cfg.train_batch_size
+                batch_size=cfg.train_batch_size,
+                max_seq_length=cfg.max_seq_length
             )
         elif cfg.algorithm == "FedAdam":
             trainer = FedAdamTrainer(
@@ -55,7 +57,8 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 server_lr=0.01,
                 learning_rate=cfg.learning_rate,
                 scheduler_type=cfg.lr_scheduler_type,
-                batch_size=cfg.train_batch_size
+                batch_size=cfg.train_batch_size,
+                max_seq_length=cfg.max_seq_length
             )
         else:
             raise ValueError(f"Unsupported algorithm: {cfg.algorithm}")
@@ -63,7 +66,11 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
         global_model = trainer.train_round(global_model, clients_data)
 
         # Evaluate on test sentences
-        metrics = evaluate_model(global_model, tokenizer, test_sents, label_list)
+        metrics = evaluate_model(
+            global_model, tokenizer, test_sents, label_list,
+            max_seq_length=cfg.max_seq_length,
+            eval_batch_size=cfg.eval_batch_size
+        )
         elapsed = log.stop_timer()
         log.log_round_metrics(r+1, metrics, elapsed)
 
@@ -89,11 +96,16 @@ def run_centralized_training(cfg, tokenizer, label_list, train_sents, test_sents
         epochs=cfg.local_epochs,
         learning_rate=cfg.learning_rate,
         scheduler_type=cfg.lr_scheduler_type,
-        batch_size=cfg.train_batch_size
+        batch_size=cfg.train_batch_size,
+        max_seq_length=cfg.max_seq_length
     )
     elapsed = log.stop_timer()
 
-    metrics = evaluate_model(model, tokenizer, test_sents, label_list)
+    metrics = evaluate_model(
+        model, tokenizer, test_sents, label_list,
+        max_seq_length=cfg.max_seq_length,
+        eval_batch_size=cfg.eval_batch_size
+    )
     log.log_round_metrics(1, metrics, elapsed)
 
     print(f" Centralized | F1 {metrics['f1']:.4f} | "

--- a/trainers/central_trainer.py
+++ b/trainers/central_trainer.py
@@ -11,7 +11,8 @@ def centralized_train(model,
                       epochs=10,
                       learning_rate=3e-5,
                       scheduler_type="constant",
-                      batch_size=32):
+                      batch_size=32,
+                      max_seq_length=128):
 
     label2id = {label: i for i, label in enumerate(label_list)}
 
@@ -21,7 +22,7 @@ def centralized_train(model,
             truncation=True,
             is_split_into_words=True,
             padding="max_length",
-            max_length=128
+            max_length=max_seq_length
         )
         tokenized["labels"] = align_labels_with_tokens(tokenized, [example["labels"]], label2id)[0]
         return tokenized

--- a/trainers/fedadam_trainer.py
+++ b/trainers/fedadam_trainer.py
@@ -29,12 +29,14 @@ def subsample_data(examples, sample_size=200):
 class FedAdamTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
                  epochs=2, learning_rate=5e-5, scheduler_type="constant",
-                 batch_size=32, server_lr=0.01, train_last_n=4, sample_size=200):
+                 batch_size=32, server_lr=0.01, train_last_n=4,
+                 sample_size=200, max_seq_length=128):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.learning_rate = learning_rate
         self.scheduler_type = scheduler_type
         self.batch_size = batch_size
+        self.max_seq_length = max_seq_length
         self.server_lr = server_lr
         self.train_last_n = train_last_n
         self.sample_size = sample_size
@@ -52,7 +54,7 @@ class FedAdamTrainer(BaseFederatedTrainer):
                 truncation=True,
                 is_split_into_words=True,
                 padding="max_length",
-                max_length=128,
+                max_length=self.max_seq_length,
             )
             tokenized["labels"] = align_labels_with_tokens(tokenized, [example["labels"]], self.label2id)[0]
             return tokenized

--- a/trainers/fedavg_trainer.py
+++ b/trainers/fedavg_trainer.py
@@ -29,12 +29,14 @@ def subsample_data(examples, sample_size=200):
 
 class FedAvgTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
-                 epochs=1, learning_rate=3e-5, scheduler_type="constant", batch_size=32):
+                 epochs=1, learning_rate=3e-5, scheduler_type="constant",
+                 batch_size=32, max_seq_length=128):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.learning_rate = learning_rate
         self.scheduler_type = scheduler_type
         self.batch_size = batch_size
+        self.max_seq_length = max_seq_length
         self.label2id = {l: i for i, l in enumerate(label_list)}
 
     def preprocess(self, examples):
@@ -44,7 +46,7 @@ class FedAvgTrainer(BaseFederatedTrainer):
                 truncation=True,
                 is_split_into_words=True,
                 padding="max_length",
-                max_length=128
+                max_length=self.max_seq_length
             )
             tokenized["labels"] = align_labels_with_tokens(tokenized, [example["labels"]], self.label2id)[0]
             return tokenized

--- a/trainers/fedprox_trainer.py
+++ b/trainers/fedprox_trainer.py
@@ -26,7 +26,8 @@ def get_client_model(global_model, device):
 def train_local_model(
     model, tokenizer, train_examples, label_list, device,
     epochs, batch_size, learning_rate, scheduler_type,
-    prox_mu, global_weights, trainable_layers=2, sample_size=200
+    prox_mu, global_weights, trainable_layers=2, sample_size=200,
+    max_seq_length=128
 ):
     label2id = {l: i for i, l in enumerate(label_list)}
     sampled_data = subsample_data(train_examples, sample_size)
@@ -38,7 +39,7 @@ def train_local_model(
             truncation=True,
             is_split_into_words=True,
             padding="max_length",
-            max_length=128,
+            max_length=max_seq_length,
         )
         tokenized["labels"] = align_labels_with_tokens(tokenized, [example["labels"]], label2id)[0]
         return tokenized
@@ -91,7 +92,8 @@ def train_local_model(
 class FedProxTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
                  epochs=1, mu=0.1, batch_size=32, learning_rate=3e-5,
-                 scheduler_type="constant", trainable_layers=4, sample_size=200):
+                 scheduler_type="constant", trainable_layers=4, sample_size=200,
+                 max_seq_length=128):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.mu = mu
@@ -100,6 +102,7 @@ class FedProxTrainer(BaseFederatedTrainer):
         self.scheduler_type = scheduler_type
         self.trainable_layers = trainable_layers
         self.sample_size = sample_size
+        self.max_seq_length = max_seq_length
 
     def train_round(self, global_model, clients_data):
         global_weights = global_model.state_dict()
@@ -119,7 +122,8 @@ class FedProxTrainer(BaseFederatedTrainer):
                 prox_mu=self.mu,
                 global_weights=global_weights,
                 trainable_layers=self.trainable_layers,
-                sample_size=self.sample_size
+                sample_size=self.sample_size,
+                max_seq_length=self.max_seq_length
             )
             client_models.append(trained.cpu())
         return self.aggregate(client_models)

--- a/utils/evaluate.py
+++ b/utils/evaluate.py
@@ -22,7 +22,8 @@ def align_labels_with_tokens(tokenized_inputs, labels, label2id):
         aligned_labels.append(label_ids)
     return aligned_labels
 
-def evaluate_model(model, tokenizer, test_examples, label_list):
+def evaluate_model(model, tokenizer, test_examples, label_list,
+                   max_seq_length=128, eval_batch_size=8):
     label2id = {label: i for i, label in enumerate(label_list)}
     id2label = {i: label for label, i in label2id.items()}
 
@@ -33,7 +34,7 @@ def evaluate_model(model, tokenizer, test_examples, label_list):
                               truncation=True,
                               is_split_into_words=True,
                               padding="max_length",
-                              max_length=128)
+                              max_length=max_seq_length)
         tokenized["labels"] = align_labels_with_tokens(tokenized, [example["labels"]], label2id)[0]
         return tokenized
 
@@ -41,7 +42,7 @@ def evaluate_model(model, tokenizer, test_examples, label_list):
 
     args = TrainingArguments(
         output_dir="./eval_tmp",
-        per_device_eval_batch_size=8
+        per_device_eval_batch_size=eval_batch_size
     )
     trainer = Trainer(model=model, args=args, tokenizer=tokenizer)
     predictions = trainer.predict(test_ds)

--- a/utils/evaluate_global_on_local.py
+++ b/utils/evaluate_global_on_local.py
@@ -4,7 +4,10 @@ from typing import List, Dict
 from .evaluate import evaluate_model
 
 
-def evaluate_global_on_local(model, tokenizer, clients_dev_sets: List[List[Dict]], label_list: List[str]):
+def evaluate_global_on_local(model, tokenizer, clients_dev_sets: List[List[Dict]],
+                             label_list: List[str],
+                             max_seq_length: int = 128,
+                             eval_batch_size: int = 8):
     """Evaluate global model on each client's validation set.
 
     Parameters
@@ -27,7 +30,11 @@ def evaluate_global_on_local(model, tokenizer, clients_dev_sets: List[List[Dict]
     """
     client_metrics = []
     for dev_data in clients_dev_sets:
-        metrics = evaluate_model(model, tokenizer, dev_data, label_list)
+        metrics = evaluate_model(
+            model, tokenizer, dev_data, label_list,
+            max_seq_length=max_seq_length,
+            eval_batch_size=eval_batch_size
+        )
         client_metrics.append(metrics)
 
     if client_metrics:


### PR DESCRIPTION
## Summary
- allow trainers and evaluation utilities to set `max_seq_length` and `eval_batch_size`
- update `evaluate_model` to accept `eval_batch_size`
- propagate the new parameters in `run_experiment.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce9607f548328b60029bab57ecc97