### PR TITLE
Rename scheduler_type param

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -36,7 +36,7 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 model_init, tokenizer, label_list, device,
                 epochs=cfg.local_epochs,
                 learning_rate=cfg.learning_rate,
-                scheduler_type=cfg.lr_scheduler_type,
+                lr_scheduler_type=cfg.lr_scheduler_type,
                 batch_size=cfg.train_batch_size
             )
         elif cfg.algorithm == "FedProx":
@@ -45,7 +45,7 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 epochs=cfg.local_epochs,
                 mu=0.1,
                 learning_rate=cfg.learning_rate,
-                scheduler_type=cfg.lr_scheduler_type,
+                lr_scheduler_type=cfg.lr_scheduler_type,
                 batch_size=cfg.train_batch_size
             )
         elif cfg.algorithm == "FedAdam":
@@ -54,7 +54,7 @@ def run_federated_training(cfg, tokenizer, label_list, clients_data, test_sents,
                 epochs=cfg.local_epochs,
                 server_lr=0.01,
                 learning_rate=cfg.learning_rate,
-                scheduler_type=cfg.lr_scheduler_type,
+                lr_scheduler_type=cfg.lr_scheduler_type,
                 batch_size=cfg.train_batch_size
             )
         else:
@@ -88,7 +88,7 @@ def run_centralized_training(cfg, tokenizer, label_list, train_sents, test_sents
         model, tokenizer, train_sents, label_list, device,
         epochs=cfg.local_epochs,
         learning_rate=cfg.learning_rate,
-        scheduler_type=cfg.lr_scheduler_type,
+        lr_scheduler_type=cfg.lr_scheduler_type,
         batch_size=cfg.train_batch_size
     )
     elapsed = log.stop_timer()

--- a/trainers/central_trainer.py
+++ b/trainers/central_trainer.py
@@ -10,7 +10,7 @@ def centralized_train(model,
                       device="cpu",
                       epochs=10,
                       learning_rate=3e-5,
-                      scheduler_type="constant",
+                      lr_scheduler_type="constant",
                       batch_size=32):
 
     label2id = {label: i for i, label in enumerate(label_list)}
@@ -32,7 +32,7 @@ def centralized_train(model,
         per_device_train_batch_size=batch_size,
         num_train_epochs=epochs,
         learning_rate=learning_rate,
-        lr_scheduler_type=scheduler_type,
+        lr_scheduler_type=lr_scheduler_type,
         logging_strategy="epoch",
         save_strategy="no",
         report_to="none"

--- a/trainers/fedadam_trainer.py
+++ b/trainers/fedadam_trainer.py
@@ -28,12 +28,12 @@ def subsample_data(examples, sample_size=200):
 
 class FedAdamTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
-                 epochs=2, learning_rate=5e-5, scheduler_type="constant",
+                 epochs=2, learning_rate=5e-5, lr_scheduler_type="constant",
                  batch_size=32, server_lr=0.01, train_last_n=4, sample_size=200):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.learning_rate = learning_rate
-        self.scheduler_type = scheduler_type
+        self.lr_scheduler_type = lr_scheduler_type
         self.batch_size = batch_size
         self.server_lr = server_lr
         self.train_last_n = train_last_n
@@ -71,7 +71,7 @@ class FedAdamTrainer(BaseFederatedTrainer):
             save_strategy="no",
             report_to="none",
             learning_rate=self.learning_rate,
-            lr_scheduler_type=self.scheduler_type,
+            lr_scheduler_type=self.lr_scheduler_type,
             fp16=True
         )
         trainer = Trainer(

--- a/trainers/fedavg_trainer.py
+++ b/trainers/fedavg_trainer.py
@@ -29,11 +29,11 @@ def subsample_data(examples, sample_size=200):
 
 class FedAvgTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
-                 epochs=1, learning_rate=3e-5, scheduler_type="constant", batch_size=32):
+                 epochs=1, learning_rate=3e-5, lr_scheduler_type="constant", batch_size=32):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.learning_rate = learning_rate
-        self.scheduler_type = scheduler_type
+        self.lr_scheduler_type = lr_scheduler_type
         self.batch_size = batch_size
         self.label2id = {l: i for i, l in enumerate(label_list)}
 
@@ -62,7 +62,7 @@ class FedAvgTrainer(BaseFederatedTrainer):
             save_strategy="no",
             report_to="none",
             learning_rate=self.learning_rate,
-            lr_scheduler_type=self.scheduler_type,
+            lr_scheduler_type=self.lr_scheduler_type,
             fp16=True  # 如果不支持可以设为 False 或去掉
         )
         trainer = Trainer(

--- a/trainers/fedprox_trainer.py
+++ b/trainers/fedprox_trainer.py
@@ -25,7 +25,7 @@ def get_client_model(global_model, device):
 
 def train_local_model(
     model, tokenizer, train_examples, label_list, device,
-    epochs, batch_size, learning_rate, scheduler_type,
+    epochs, batch_size, learning_rate, lr_scheduler_type,
     prox_mu, global_weights, trainable_layers=2, sample_size=200
 ):
     label2id = {l: i for i, l in enumerate(label_list)}
@@ -70,7 +70,7 @@ def train_local_model(
         per_device_train_batch_size=batch_size,
         num_train_epochs=epochs,
         learning_rate=learning_rate,
-        lr_scheduler_type=scheduler_type,
+        lr_scheduler_type=lr_scheduler_type,
         logging_strategy="no",
         save_strategy="no",
         report_to="none",
@@ -91,13 +91,13 @@ def train_local_model(
 class FedProxTrainer(BaseFederatedTrainer):
     def __init__(self, model_init, tokenizer, label_list, device="cpu",
                  epochs=1, mu=0.1, batch_size=32, learning_rate=3e-5,
-                 scheduler_type="constant", trainable_layers=4, sample_size=200):
+                 lr_scheduler_type="constant", trainable_layers=4, sample_size=200):
         super().__init__(model_init, tokenizer, label_list, device)
         self.epochs = epochs
         self.mu = mu
         self.batch_size = batch_size
         self.learning_rate = learning_rate
-        self.scheduler_type = scheduler_type
+        self.lr_scheduler_type = lr_scheduler_type
         self.trainable_layers = trainable_layers
         self.sample_size = sample_size
 
@@ -115,7 +115,7 @@ class FedProxTrainer(BaseFederatedTrainer):
                 epochs=self.epochs,
                 batch_size=self.batch_size,
                 learning_rate=self.learning_rate,
-                scheduler_type=self.scheduler_type,
+                lr_scheduler_type=self.lr_scheduler_type,
                 prox_mu=self.mu,
                 global_weights=global_weights,
                 trainable_layers=self.trainable_layers,


### PR DESCRIPTION
## Summary
- rename `scheduler_type` parameters to `lr_scheduler_type` in all trainers
- update trainer usage in `run_experiment.py`

## Testing
- `python -m py_compile run_experiment.py trainers/*.py config/*.py model_loader.py data_loader.py utils/*.py aggregators/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0764e2788328be16c02e04226a2e