### PR TITLE
Fix device naming

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -38,5 +38,5 @@ class Config:
         # 其他设置
         misc = cfg.get("misc", {})
         self.seed         = misc.get("seed", 42)
-        self.device_mode  = misc.get("device", "auto")
+        self.device       = misc.get("device", "auto")
         self.save_results = misc.get("save_results", True)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,5 +24,5 @@ hyperparameters:
   lr_scheduler_type: constant 
 misc:
   seed: 42
-  device: auto               # Options: auto, cpu, cuda
+  device: auto               # Options: auto, cpu, or cuda (auto uses cuda if available)
   save_results: true

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -139,7 +139,7 @@ def main():
     if args.num_clients is not None:
         cfg.num_clients = args.num_clients
 
-    device = "cuda" if torch.cuda.is_available() and cfg.device_mode != "cpu" else "cpu"
+    device = "cuda" if torch.cuda.is_available() and cfg.device != "cpu" else "cpu"
 
     # Load and split data into sentence-level lists
     client_train_sents, dev_sents, test_sents = load_and_split_pubtator(


### PR DESCRIPTION
## Summary
- clean up naming for the device setting
- adjust main script to read `cfg.device`
- clarify device comment in config

## Testing
- `python -m py_compile run_experiment.py config/config.py`

------
https://chatgpt.com/codex/tasks/task_e_688d07671f7883288f5302c83f821dd2